### PR TITLE
Removed the leading backslash on imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See the API documentation for more details.
 ```php
 <?php
 require_once 'vendor/autoload.php';
-use \GeoIp2\Database\Reader;
+use GeoIp2\Database\Reader;
 
 // This creates the Reader object, which should be reused across
 // lookups.
@@ -127,7 +127,7 @@ See the API documentation for more details.
 ```php
 <?php
 require_once 'vendor/autoload.php';
-use \GeoIp2\WebService\Client;
+use GeoIp2\WebService\Client;
 
 // This creates a Client object that can be reused across requests.
 // Replace "42" with your user ID and "license_key" with your license


### PR DESCRIPTION
According to [php.net](http://php.net/manual/en/language.namespaces.importing.php):

> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as Foo\Bar as opposed to global names that do not, such as FooBar), the leading backslash is unnecessary and not recommended, as import names must be fully qualified, and are not processed relative to the current namespace.
