### PR TITLE
Update composer.json to require bcmath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "guzzle/guzzle": "3.*",
         "maxmind-db/reader": "0.2.*",
+        "ext-bcmath":"*",
         "php": ">=5.3.1"
     },
     "require-dev": {


### PR DESCRIPTION
I tried running GeoIP2 on a box without the BC Math PHP extension and got the error:

Fatal error: Call to undefined function MaxMind\Db\Reader\bcadd() in /home/vagrant/Akkroo/publish/vendor/maxmind-db/reader/src/MaxMind/Db/Reader/Decoder.php on line 252

The library should depend on ext-bcmath to ensure users do not run in to this problem.
