### PR TITLE
Remove development stuff from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/bin/ export-ignore
+/dev-bin/ export-ignore
+/tests/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/box.json export-ignore
+/phar-stub.php export-ignore
+/phpunit.xml.dist export-ignore
+/README.dev.md export-ignore


### PR DESCRIPTION
`composer require` currently downloads all the contents of the repository, but for production usage the development stuff is not required (and it could may be harmful if it contains executable files).

What about removing this development stuff from releases?

This affects only installing releases: git-cloning is not touched, so that people that want to run tests/build phars can perform a `git clone`

