### PR TITLE
Removes some more unneeded files from packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
 /bin/ export-ignore
 /dev-bin/ export-ignore
+/maxmind-db/ export-ignore
 /tests/ export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.gitmodules export-ignore
 /.travis.yml export-ignore
+/.php_cs export-ignore
 /box.json export-ignore
 /phar-stub.php export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
Using geoip2 via composer currently includes some files that are not required and thus could be removed from export.