### PR TITLE
Lazy load the GeoIP2 database reader

### DIFF
--- a/src/Database/Reader.php
+++ b/src/Database/Reader.php
@@ -261,8 +261,8 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * @throws \InvalidArgumentException if arguments are passed to the method
-     * @throws \BadMethodCallException   if the database has been closed
+     * @throws \InvalidArgumentException                   if arguments are passed to the method
+     * @throws \BadMethodCallException                     if the database has been closed
      * @throws \MaxMind\Db\Reader\InvalidDatabaseException if the database
      *                                                     is corrupt or invalid
      *


### PR DESCRIPTION
Reader service reads the database file in the constructor. This leads to a decrease in performance if you use the Reader in dependencies, but do not use the methods of Reader. It will be more economical to read the database if this is really necessary. This also leads to an application initialization error if the database file is not present at the moment.

This problem causes quite a lot of inconvenience. Now i must to use the [proxy class](https://github.com/gpslab/geoip2/blob/2.0/src/Database/ProxyReader.php) for lazy loading of the database reader.

This small fix will solve my problems.

*I will not say that instantiating a rader in a constructor is a violation of the SOLID. Fixing this problem will break backward compatibility.*