### PR TITLE
Remove hhvm support from readme/travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
-    - php: hhvm
     - php: nightly
   allow_failures:
     - php: nightly

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ to the client API, please see
 
 ## Requirements  ##
 
-This library requires PHP 5.4 or greater. This library is also compatible with HHVM. 
+This library requires PHP 5.4 or greater.
 
 This library also relies on the [MaxMind DB Reader](https://github.com/maxmind/MaxMind-DB-Reader-php).
 


### PR DESCRIPTION
HHVM 4.0 is released and the version that travis runs, and it [no longer supports php](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html).