### PR TITLE
Test enhancement

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,6 +24,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_alias_tag' => false,
         'phpdoc_order' => true,
         'semicolon_after_instruction' => true,
+        'single_line_throw' => false,
         'strict_comparison' => true,
         'strict_param' => true,
         'yoda_style' => false,

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - php: 'nightly'
 
 before_install:
-  - composer install --dev -n --prefer-source
+  - composer install -n --prefer-source
   - phpenv rehash
   - "if [[ $RUN_SNYK && $SNYK_TOKEN ]]; then sudo apt-get install -y nodejs; npm install -g snyk; fi"
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.*",
-        "phpunit/phpunit": "4.* || 5.*",
+        "phpunit/phpunit": "^4.8.36 || 5.*",
         "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {

--- a/tests/GeoIp2/Test/Database/ReaderTest.php
+++ b/tests/GeoIp2/Test/Database/ReaderTest.php
@@ -3,11 +3,12 @@
 namespace GeoIp2\Test\Database;
 
 use GeoIp2\Database\Reader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class ReaderTest extends \PHPUnit_Framework_TestCase
+class ReaderTest extends TestCase
 {
     public function databaseTypes()
     {

--- a/tests/GeoIp2/Test/Model/CountryTest.php
+++ b/tests/GeoIp2/Test/Model/CountryTest.php
@@ -3,11 +3,12 @@
 namespace GeoIp2\Test\Model;
 
 use GeoIp2\Model\Country;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class CountryTest extends \PHPUnit_Framework_TestCase
+class CountryTest extends TestCase
 {
     private $raw = [
         'continent' => [
@@ -34,7 +35,7 @@ class CountryTest extends \PHPUnit_Framework_TestCase
 
     private $model;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->model = new Country($this->raw, ['en']);
     }

--- a/tests/GeoIp2/Test/Model/InsightsTest.php
+++ b/tests/GeoIp2/Test/Model/InsightsTest.php
@@ -3,11 +3,12 @@
 namespace GeoIp2\Test\Model;
 
 use GeoIp2\Model\Insights;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class InsightsTest extends \PHPUnit_Framework_TestCase
+class InsightsTest extends TestCase
 {
     public function testFull()
     {

--- a/tests/GeoIp2/Test/Model/NameTest.php
+++ b/tests/GeoIp2/Test/Model/NameTest.php
@@ -3,11 +3,12 @@
 namespace GeoIp2\Test\Model;
 
 use GeoIp2\Model\Country;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class NameTest extends \PHPUnit_Framework_TestCase
+class NameTest extends TestCase
 {
     public $raw = [
         'continent' => [

--- a/tests/GeoIp2/Test/UtilTest.php
+++ b/tests/GeoIp2/Test/UtilTest.php
@@ -3,11 +3,12 @@
 namespace GeoIp2\Test;
 
 use GeoIp2\Util;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     public function testCidr()
     {

--- a/tests/GeoIp2/Test/WebService/ClientTest.php
+++ b/tests/GeoIp2/Test/WebService/ClientTest.php
@@ -4,11 +4,12 @@ namespace GeoIp2\Test\WebService;
 
 use Composer\CaBundle\CaBundle;
 use MaxMind\WebService\Client as WsClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     private $country = [
             'continent' => [


### PR DESCRIPTION
# Changed log
- Add `single_line_throw` rule for `PHP-CS-Fixer`.
- Removing `--dev` option because it's deprecated. The deprecated warning message is as follows:
```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- To support future latest stable `PHPUnit` version, defining the `^4.8.36` version and using the `PHPUnit\Framework\TestCase` namespace.