### PR TITLE
Test on php-7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
-    - php: '7.4snapshot'
+    - php: '7.4'
     - php: 'master'
     - php: 'nightly'
   fast_finish: true
   allow_failures:
-    - php: '7.4snapshot'
     - php: 'master'
     - php: 'nightly'
 


### PR DESCRIPTION
- The `php-7.4` is stable and available on Travis CI build. Using the `php-7.4` version instead.