### PR TITLE
Fix typo in the doc

### DIFF
--- a/src/Record/City.php
+++ b/src/Record/City.php
@@ -18,7 +18,7 @@ namespace GeoIp2\Record;
  * @property-read string|null $name The name of the city based on the locales list
  * passed to the constructor. This attribute is returned by all location
  * services and databases.
- * @property-read array|null $names A array map where the keys are locale codes
+ * @property-read array|null $names An array map where the keys are locale codes
  * and the values are names. This attribute is returned by all location
  * services and databases.
  */


### PR DESCRIPTION
Fix a small typo I've noticed in the docBlock.

`a array` => `an array`

Hope It still helps 🙂