### PR TITLE
Remove unnecessary PHPStan directive

### DIFF
--- a/src/Record/AbstractPlaceRecord.php
+++ b/src/Record/AbstractPlaceRecord.php
@@ -57,7 +57,6 @@ abstract class AbstractPlaceRecord extends AbstractRecord
     private function firstSetNameLocale(): ?string
     {
         foreach ($this->locales as $locale) {
-            // @phpstan-ignore-next-line
             if (isset($this->names[$locale])) {
                 return $locale;
             }


### PR DESCRIPTION
PHPStan 1.6.3 is saying "No error to ignore is reported on line 61."