### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
   `subdivisions` array. This provides compatibility with some third-party
   databases that publish empty subdivisions arrays. Pull request by Jarek
   Jakubowski. GitHub #290.
+* The `GeoIP2` prefix in web service error messages has been changed to
+  `GeoIP`.
 
 3.3.0 (2025-11-20)
 ------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 **GeoIP2-php** is MaxMind's official PHP client library for:
-- **GeoIP2/GeoLite2 Web Services**: Country, City, and Insights endpoints
-- **GeoIP2/GeoLite2 Databases**: Local MMDB file reading for various database types (City, Country, ASN, Anonymous IP, Anonymous Plus, ISP, etc.)
+- **GeoIP/GeoLite Web Services**: Country, City Plus, and Insights endpoints
+- **GeoIP/GeoLite Databases**: Local MMDB file reading for various database types (City, Country, ASN, Anonymous IP, Anonymous Plus, ISP, etc.)
 
 The library provides both web service clients and database readers that return strongly-typed model objects containing geographic, ISP, anonymizer, and other IP-related data.
 
@@ -323,6 +323,6 @@ vendor/bin/phpunit
 ## Additional Resources
 
 - [API Documentation](https://maxmind.github.io/GeoIP2-php/)
-- [GeoIP2 Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services)
+- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services)
 - [MaxMind DB Format](https://maxmind.github.io/MaxMind-DB/)
 - GitHub Issues: https://github.com/maxmind/GeoIP2-php/issues

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# GeoIP2 PHP API
+# GeoIP PHP API
 
 ## Description
 
-This package provides an API for the GeoIP2 and GeoLite2
+This package provides an API for the GeoIP and GeoLite
 [web services](https://dev.maxmind.com/geoip/docs/web-services?lang=en) and
 [databases](https://dev.maxmind.com/geoip/docs/databases?lang=en).
 
@@ -46,7 +46,7 @@ require 'vendor/autoload.php';
 
 Although we strongly recommend using Composer, we also provide a
 [phar archive](https://php.net/manual/en/book.phar.php) containing most of the
-dependencies for GeoIP2. Our latest phar archive is available on
+dependencies for GeoIP. Our latest phar archive is available on
 [our releases page](https://github.com/maxmind/GeoIP2-php/releases).
 
 ### Install Dependencies
@@ -80,7 +80,7 @@ require 'geoip2.phar';
 
 The [MaxMind DB API](https://github.com/maxmind/MaxMind-DB-Reader-php)
 includes an optional C extension that you may install to dramatically increase
-the performance of lookups in GeoIP2 or GeoLite2 databases. To install, please
+the performance of lookups in GeoIP or GeoLite databases. To install, please
 follow the instructions included with that API.
 
 The extension has no effect on web-service lookups.
@@ -88,7 +88,7 @@ The extension has no effect on web-service lookups.
 ## IP Geolocation Usage
 
 IP geolocation is inherently imprecise. Locations are often near the center of
-the population. Any location provided by a GeoIP2 database or web service
+the population. Any location provided by a GeoIP database or web service
 should not be used to identify a particular address or household.
 
 ## Database Reader
@@ -304,14 +304,14 @@ argument specifies the language preferences when using the `->name` method on
 the model classes that this client creates. The fourth argument is additional
 options such as `host` and `timeout`.
 
-For instance, to call the GeoLite2 web service instead of the GeoIP2 web
+For instance, to call the GeoLite web service instead of the GeoIP web
 service:
 
 ```php
 $client = new Client(42, 'abcdef123456', ['en'], ['host' => 'geolite.info']);
 ```
 
-To call the Sandbox GeoIP2 web service instead of the production GeoIP2 web
+To call the Sandbox GeoIP web service instead of the production GeoIP web
 service:
 
 ```php
@@ -344,10 +344,10 @@ use GeoIp2\WebService\Client;
 // This creates a Client object that can be reused across requests.
 // Replace "42" with your account ID and "license_key" with your license
 // key. Set the "host" to "geolite.info" in the fourth argument options
-// array to use the GeoLite2 web service instead of the GeoIP2 web
+// array to use the GeoLite web service instead of the GeoIP web
 // service. Set the "host" to "sandbox.maxmind.com" in the fourth argument
-// options array to use the Sandbox GeoIP2 web service instead of the
-// production GeoIP2 web service.
+// options array to use the Sandbox GeoIP web service instead of the
+// production GeoIP web service.
 $client = new Client(42, 'abcdef123456');
 
 // Replace "city" with the method corresponding to the web service that
@@ -398,7 +398,7 @@ Because of these factors, it is possible for any endpoint to return a record
 where some or all of the attributes are unpopulated.
 
 See the
-[GeoIP2 web service docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
+[GeoIP web service docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
 for details on what data each endpoint may return.
 
 The only piece of data which is always returned is the `ipAddress` attribute
@@ -411,7 +411,7 @@ databases with data on geographical features around the world, including
 populated places. They offer both free and paid premium data. Each feature is
 uniquely identified by a `geonameId`, which is an integer.
 
-Many of the records returned by the GeoIP2 web services and databases include
+Many of the records returned by the GeoIP web services and databases include
 a `geonameId` property. This is the ID of a geographical feature (city,
 region, country, etc.) in the GeoNames database.
 
@@ -460,7 +460,7 @@ initial clone, or from https://github.com/maxmind/MaxMind-DB
 
 ## Versioning
 
-The GeoIP2 PHP API uses [Semantic Versioning](https://semver.org/).
+The GeoIP PHP API uses [Semantic Versioning](https://semver.org/).
 
 ## Copyright and License
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "geoip2/geoip2",
-    "description": "MaxMind GeoIP2 PHP API",
+    "description": "MaxMind GeoIP PHP API",
     "keywords": ["geoip", "geoip2", "geolocation", "ip", "maxmind"],
     "homepage": "https://github.com/maxmind/GeoIP2-php",
     "type": "library",

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -157,7 +157,7 @@ rm -rf "$cachedir"
 php phpDocumentor.phar \
     --visibility=public \
     --cache-folder="$cachedir" \
-    --title="GeoIP2 PHP API $tag" \
+    --title="GeoIP PHP API $tag" \
     run \
     -d "$PWD/../src" \
     -t "doc/$tag"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,4 +1,4 @@
-title = "MaxMind GeoIP2 PHP API"
+title = "MaxMind GeoIP PHP API"
 disableKinds = ["taxonomy", "term", "RSS"]
 
 [[cascade]]

--- a/src/Database/Reader.php
+++ b/src/Database/Reader.php
@@ -20,7 +20,7 @@ use MaxMind\Db\Reader\InvalidDatabaseException;
 use MaxMind\Db\Reader\Metadata;
 
 /**
- * Instances of this class provide a reader for the GeoIP2 database format.
+ * Instances of this class provide a reader for the GeoIP database format.
  * IP addresses can be looked up using the database specific methods.
  *
  * ## Usage ##
@@ -51,7 +51,7 @@ class Reader implements ProviderInterface
     /**
      * Constructor.
      *
-     * @param string        $filename the path to the GeoIP2 database file
+     * @param string        $filename the path to the GeoIP database file
      * @param array<string> $locales  list of locale codes to use in name property
      *                                from most preferred to least preferred
      *
@@ -67,7 +67,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 City model.
+     * This method returns a GeoIP City model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -81,7 +81,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 Country model.
+     * This method returns a GeoIP Country model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -95,7 +95,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 Anonymous IP model.
+     * This method returns a GeoIP Anonymous IP model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -131,7 +131,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoLite2 ASN model.
+     * This method returns a GeoLite ASN model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -149,7 +149,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 Connection Type model.
+     * This method returns a GeoIP Connection Type model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -167,7 +167,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 Domain model.
+     * This method returns a GeoIP Domain model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -185,7 +185,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 Enterprise model.
+     * This method returns a GeoIP Enterprise model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -199,7 +199,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * This method returns a GeoIP2 ISP model.
+     * This method returns a GeoIP ISP model.
      *
      * @param string $ipAddress an IPv4 or IPv6 address as a string
      *
@@ -283,7 +283,7 @@ class Reader implements ProviderInterface
     }
 
     /**
-     * Closes the GeoIP2 database and returns the resources to the system.
+     * Closes the GeoIP database and returns the resources to the system.
      */
     public function close(): void
     {

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GeoIp2\Exception;
 
 /**
- * This class represents an error returned by MaxMind's GeoIP2
+ * This class represents an error returned by MaxMind's GeoIP
  * web service.
  */
 class InvalidRequestException extends HttpException

--- a/src/Model/AnonymousIp.php
+++ b/src/Model/AnonymousIp.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Util;
 
 /**
- * This class provides the GeoIP2 Anonymous IP model.
+ * This class provides the GeoIP Anonymous IP model.
  */
 class AnonymousIp implements \JsonSerializable
 {

--- a/src/Model/Asn.php
+++ b/src/Model/Asn.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Util;
 
 /**
- * This class provides the GeoLite2 ASN model.
+ * This class provides the GeoLite ASN model.
  */
 class Asn implements \JsonSerializable
 {

--- a/src/Model/ConnectionType.php
+++ b/src/Model/ConnectionType.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Util;
 
 /**
- * This class provides the GeoIP2 Connection-Type model.
+ * This class provides the GeoIP Connection-Type model.
  */
 class ConnectionType implements \JsonSerializable
 {

--- a/src/Model/Country.php
+++ b/src/Model/Country.php
@@ -11,7 +11,7 @@ use GeoIp2\Record\RepresentedCountry;
 use GeoIp2\Record\Traits;
 
 /**
- * Model class for the data returned by GeoIP2 Country web service and database.
+ * Model class for the data returned by GeoIP Country web service and database.
  *
  * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for more details.
  */

--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Util;
 
 /**
- * This class provides the GeoIP2 Domain model.
+ * This class provides the GeoIP Domain model.
  */
 class Domain implements \JsonSerializable
 {

--- a/src/Model/Enterprise.php
+++ b/src/Model/Enterprise.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GeoIp2\Model;
 
 /**
- * Model class for the data returned by GeoIP2 Enterprise database lookups.
+ * Model class for the data returned by GeoIP Enterprise database lookups.
  *
  * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for more
  * details.

--- a/src/Model/Insights.php
+++ b/src/Model/Insights.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Record\Anonymizer;
 
 /**
- * Model class for the data returned by GeoIP2 Insights web service.
+ * Model class for the data returned by GeoIP Insights web service.
  *
  * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for
  * more details.

--- a/src/Model/Isp.php
+++ b/src/Model/Isp.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 use GeoIp2\Util;
 
 /**
- * This class provides the GeoIP2 ISP model.
+ * This class provides the GeoIP ISP model.
  */
 class Isp implements \JsonSerializable
 {

--- a/src/Record/AbstractPlaceRecord.php
+++ b/src/Record/AbstractPlaceRecord.php
@@ -9,7 +9,7 @@ abstract class AbstractPlaceRecord extends AbstractNamedRecord
     /**
      * @var int|null A value from 0-100 indicating MaxMind's
      *               confidence that the location level is correct. This attribute is only available
-     *               from the Insights service and the GeoIP2 Enterprise database.
+     *               from the Insights service and the GeoIP Enterprise database.
      */
     public readonly ?int $confidence;
 

--- a/src/Record/Anonymizer.php
+++ b/src/Record/Anonymizer.php
@@ -7,20 +7,20 @@ namespace GeoIp2\Record;
 /**
  * Contains data for the anonymizer record associated with an IP address.
  *
- * This record is returned by the GeoIP2 Insights web service.
+ * This record is returned by the GeoIP Insights web service.
  */
 class Anonymizer implements \JsonSerializable
 {
     /**
      * @var int|null A confidence score from 1-99 indicating our confidence that the IP
      *               address is a VPN. Currently, this is either 30 or 99. This attribute is
-     *               only available from the GeoIP2 Insights web service.
+     *               only available from the GeoIP Insights web service.
      */
     public readonly ?int $confidence;
 
     /**
      * @var bool This is true if the IP address belongs to any sort of anonymous network.
-     *           This attribute is only available from the GeoIP2 Insights web service.
+     *           This attribute is only available from the GeoIP Insights web service.
      */
     public readonly bool $isAnonymous;
 
@@ -28,45 +28,45 @@ class Anonymizer implements \JsonSerializable
      * @var bool This is true if the IP address is registered to an anonymous VPN provider.
      *           If a VPN provider does not register subnets under names associated with them,
      *           we will likely only flag their IP ranges using the isHostingProvider property.
-     *           This attribute is only available from the GeoIP2 Insights web service.
+     *           This attribute is only available from the GeoIP Insights web service.
      */
     public readonly bool $isAnonymousVpn;
 
     /**
      * @var bool This is true if the IP address belongs to a hosting or VPN provider (see
      *           description of isAnonymousVpn property). This attribute is only available from
-     *           the GeoIP2 Insights web service.
+     *           the GeoIP Insights web service.
      */
     public readonly bool $isHostingProvider;
 
     /**
      * @var bool This is true if the IP address belongs to a public proxy. This attribute
-     *           is only available from the GeoIP2 Insights web service.
+     *           is only available from the GeoIP Insights web service.
      */
     public readonly bool $isPublicProxy;
 
     /**
      * @var bool This is true if the IP address is on a suspected anonymizing network and
-     *           belongs to a residential ISP. This attribute is only available from the GeoIP2
+     *           belongs to a residential ISP. This attribute is only available from the GeoIP
      *           Insights web service.
      */
     public readonly bool $isResidentialProxy;
 
     /**
      * @var bool This is true if the IP address is a Tor exit node. This attribute is only
-     *           available from the GeoIP2 Insights web service.
+     *           available from the GeoIP Insights web service.
      */
     public readonly bool $isTorExitNode;
 
     /**
      * @var string|null The date the anonymizer network was last seen in YYYY-MM-DD format.
-     *                  This attribute is only available from the GeoIP2 Insights web service.
+     *                  This attribute is only available from the GeoIP Insights web service.
      */
     public readonly ?string $networkLastSeen;
 
     /**
      * @var string|null The name of the VPN provider, for example, NordVPN or SurfShark.
-     *                  This attribute is only available from the GeoIP2 Insights web service.
+     *                  This attribute is only available from the GeoIP Insights web service.
      */
     public readonly ?string $providerName;
 

--- a/src/Record/Postal.php
+++ b/src/Record/Postal.php
@@ -23,7 +23,7 @@ class Postal implements \JsonSerializable
     /**
      * @var int|null A value from 0-100 indicating MaxMind's
      *               confidence that the postal code is correct. This attribute is only
-     *               available from the Insights service and the GeoIP2 Enterprise
+     *               available from the Insights service and the GeoIP Enterprise
      *               database.
      */
     public readonly ?int $confidence;

--- a/src/Record/Traits.php
+++ b/src/Record/Traits.php
@@ -18,7 +18,7 @@ class Traits implements \JsonSerializable
      *               associated with the IP address. See
      *               https://en.wikipedia.org/wiki/Autonomous_system_(Internet%29. This attribute
      *               is only available from the City Plus and Insights web services and the
-     *               GeoIP2 Enterprise database.
+     *               GeoIP Enterprise database.
      */
     public readonly ?int $autonomousSystemNumber;
 
@@ -27,7 +27,7 @@ class Traits implements \JsonSerializable
      *                  associated with the registered autonomous system number for the IP address.
      *                  See https://en.wikipedia.org/wiki/Autonomous_system_(Internet%29. This
      *                  attribute is only available from the City Plus and Insights web services and
-     *                  the GeoIP2 Enterprise database.
+     *                  the GeoIP Enterprise database.
      */
     public readonly ?string $autonomousSystemOrganization;
 
@@ -35,7 +35,7 @@ class Traits implements \JsonSerializable
      * @var string|null The connection type may take the
      *                  following  values: "Dialup", "Cable/DSL", "Corporate", "Cellular", and
      *                  "Satellite". Additional values may be added in the future. This attribute is
-     *                  only available from the City Plus and Insights web services and the GeoIP2
+     *                  only available from the City Plus and Insights web services and the GeoIP
      *                  Enterprise database.
      */
     public readonly ?string $connectionType;
@@ -44,7 +44,7 @@ class Traits implements \JsonSerializable
      * @var string|null The second level domain associated with the
      *                  IP address. This will be something like "example.com" or "example.co.uk",
      *                  not "foo.example.com". This attribute is only available from the
-     *                  City Plus and Insights web services and the GeoIP2 Enterprise
+     *                  City Plus and Insights web services and the GeoIP Enterprise
      *                  database.
      */
     public readonly ?string $domain;
@@ -61,7 +61,7 @@ class Traits implements \JsonSerializable
 
     /**
      * @var bool This is true if the IP address belongs to
-     *           any sort of anonymous network. This property is only available from GeoIP2
+     *           any sort of anonymous network. This property is only available from GeoIP
      *           Insights.
      *
      * @deprecated use $anonymizer->isAnonymous in the Insights response instead
@@ -73,7 +73,7 @@ class Traits implements \JsonSerializable
      *           registered to an anonymous VPN provider. If a VPN provider does not register
      *           subnets under names associated with them, we will likely only flag their IP
      *           ranges using the isHostingProvider property. This property is only available
-     *           from GeoIP2 Insights.
+     *           from GeoIP Insights.
      *
      * @deprecated use $anonymizer->isAnonymousVpn in the Insights response instead
      */
@@ -89,7 +89,7 @@ class Traits implements \JsonSerializable
     /**
      * @var bool This is true if the IP address belongs
      *           to a hosting or VPN provider (see description of isAnonymousVpn property).
-     *           This property is only available from GeoIP2 Insights.
+     *           This property is only available from GeoIP Insights.
      *
      * @deprecated use $anonymizer->isHostingProvider in the Insights response instead
      */
@@ -98,14 +98,14 @@ class Traits implements \JsonSerializable
     /**
      * @var bool This attribute is true if MaxMind
      *           believes this IP address to be a legitimate proxy, such as an internal
-     *           VPN used by a corporation. This attribute is only available in the GeoIP2
+     *           VPN used by a corporation. This attribute is only available in the GeoIP
      *           Enterprise database.
      */
     public readonly bool $isLegitimateProxy;
 
     /**
      * @var bool This is true if the IP address belongs to
-     *           a public proxy. This property is only available from GeoIP2 Insights.
+     *           a public proxy. This property is only available from GeoIP Insights.
      *
      * @deprecated use $anonymizer->isPublicProxy in the Insights response instead
      */
@@ -114,7 +114,7 @@ class Traits implements \JsonSerializable
     /**
      * @var bool This is true if the IP address is
      *           on a suspected anonymizing network and belongs to a residential ISP. This
-     *           property is only available from GeoIP2 Insights.
+     *           property is only available from GeoIP Insights.
      *
      * @deprecated use $anonymizer->isResidentialProxy in the Insights response instead
      */
@@ -122,7 +122,7 @@ class Traits implements \JsonSerializable
 
     /**
      * @var bool This is true if the IP address is a Tor
-     *           exit node. This property is only available from GeoIP2 Insights.
+     *           exit node. This property is only available from GeoIP Insights.
      *
      * @deprecated use $anonymizer->isTorExitNode in the Insights response instead
      */
@@ -131,7 +131,7 @@ class Traits implements \JsonSerializable
     /**
      * @var string|null The name of the ISP associated with the IP
      *                  address. This attribute is only available from the City Plus and Insights
-     *                  web services and the GeoIP2 Enterprise database.
+     *                  web services and the GeoIP Enterprise database.
      */
     public readonly ?string $isp;
 
@@ -139,7 +139,7 @@ class Traits implements \JsonSerializable
      * @var string|null The [mobile country code
      *                  (MCC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated with
      *                  the IP address and ISP. This property is available from the City Plus and
-     *                  Insights web services and the GeoIP2 Enterprise database.
+     *                  Insights web services and the GeoIP Enterprise database.
      */
     public readonly ?string $mobileCountryCode;
 
@@ -147,7 +147,7 @@ class Traits implements \JsonSerializable
      * @var string|null The [mobile network code
      *                  (MNC)](https://en.wikipedia.org/wiki/Mobile_country_code) associated with
      *                  the IP address and ISP. This property is available from the City Plus and
-     *                  Insights web services and the GeoIP2 Enterprise database.
+     *                  Insights web services and the GeoIP Enterprise database.
      */
     public readonly ?string $mobileNetworkCode;
 
@@ -161,7 +161,7 @@ class Traits implements \JsonSerializable
     /**
      * @var string|null The name of the organization
      *                  associated with the IP address. This attribute is only available from the
-     *                  City Plus and Insights web services and the GeoIP2 Enterprise database.
+     *                  City Plus and Insights web services and the GeoIP Enterprise database.
      */
     public readonly ?string $organization;
 
@@ -172,7 +172,7 @@ class Traits implements \JsonSerializable
      *                 IP risk score provided in minFraud and is not responsive to traffic on your
      *                 network. If you need realtime IP risk scoring based on behavioral signals on
      *                 your own network, please use minFraud. This attribute is only available from
-     *                 the GeoIP2 Insights web service.
+     *                 the GeoIP Insights web service.
      *
      *                 We do not provide an IP risk snapshot for low-risk networks. If this field
      *                 is not populated, we either do not have signals for the network or the
@@ -183,7 +183,7 @@ class Traits implements \JsonSerializable
 
     /**
      * @var float|null An indicator of how static or
-     *                 dynamic an IP address is. This property is only available from GeoIP2
+     *                 dynamic an IP address is. This property is only available from GeoIP
      *                 Insights.
      */
     public readonly ?float $staticIpScore;
@@ -192,7 +192,7 @@ class Traits implements \JsonSerializable
      * @var int|null The estimated number of users sharing
      *               the IP/network during the past 24 hours. For IPv4, the count is for the
      *               individual IP. For IPv6, the count is for the /64 network. This property is
-     *               only available from GeoIP2 Insights.
+     *               only available from GeoIP Insights.
      */
     public readonly ?int $userCount;
 
@@ -219,7 +219,7 @@ class Traits implements \JsonSerializable
      * </ul>
      * <p>
      *   This attribute is only available from the Insights web service and the
-     *   GeoIP2 Enterprise database.
+     *   GeoIP Enterprise database.
      * </p>
      */
     public readonly ?string $userType;

--- a/src/WebService/Client.php
+++ b/src/WebService/Client.php
@@ -20,7 +20,7 @@ use MaxMind\Exception\WebServiceException;
 use MaxMind\WebService\Client as WsClient;
 
 /**
- * This class provides a client API for all the GeoIP2 web services.
+ * This class provides a client API for all the GeoIP web services.
  * The services are Country, City Plus, and Insights. Each service returns
  * a different set of data about an IP address, with Country returning the
  * least data and Insights the most.
@@ -65,11 +65,11 @@ class Client implements ProviderInterface
      *                                         from most preferred to least preferred
      * @param array<string, mixed> $options    array of options. Valid options include:
      *                                         * `host` - The host to use when querying the web
-     *                                         service. To query the GeoLite2 web service
-     *                                         instead of the GeoIP2 web service, set the
+     *                                         service. To query the GeoLite web service
+     *                                         instead of the GeoIP web service, set the
      *                                         host to `geolite.info`. To query the Sandbox
-     *                                         GeoIP2 web service instead of the production
-     *                                         GeoIP2 web service, set the host to
+     *                                         GeoIP web service instead of the production
+     *                                         GeoIP web service, set the host to
      *                                         `sandbox.maxmind.com`. The sandbox allows you to
      *                                         experiment with the API without affecting your
      *                                         production data.
@@ -167,7 +167,7 @@ class Client implements ProviderInterface
 
     /**
      * This method calls the Insights service. Insights is only supported by
-     * the GeoIP2 web service. The GeoLite2 web service does not support it.
+     * the GeoIP web service. The GeoLite web service does not support it.
      *
      * @param string $ipAddress IPv4 or IPv6 address as a string. If no
      *                          address is provided, the address that the web service is called
@@ -226,7 +226,7 @@ class Client implements ProviderInterface
 
         try {
             $service = (new \ReflectionClass($class))->getShortName();
-            $body = $this->client->get('GeoIP2 ' . $service, $path);
+            $body = $this->client->get('GeoIP ' . $service, $path);
         } catch (IpAddressNotFoundException $ex) {
             throw new AddressNotFoundException(
                 $ex->getMessage(),

--- a/tests/GeoIp2/Test/WebService/ClientTest.php
+++ b/tests/GeoIp2/Test/WebService/ClientTest.php
@@ -322,7 +322,7 @@ class ClientTest extends TestCase
     public function testNoBodyException(): void
     {
         $this->expectException(GeoIp2Exception::class);
-        $this->expectExceptionMessage('Received a 200 response for GeoIP2 Country but did not receive a HTTP body.');
+        $this->expectExceptionMessage('Received a 200 response for GeoIP Country but did not receive a HTTP body.');
 
         $this->makeRequest('Country', '1.2.3.5');
     }
@@ -330,7 +330,7 @@ class ClientTest extends TestCase
     public function testBadBodyException(): void
     {
         $this->expectException(GeoIp2Exception::class);
-        $this->expectExceptionMessage('Received a 200 response for GeoIP2 Country but could not decode the response as JSON:');
+        $this->expectExceptionMessage('Received a 200 response for GeoIP Country but could not decode the response as JSON:');
 
         $this->makeRequest('Country', '2.2.3.5');
     }
@@ -364,7 +364,7 @@ class ClientTest extends TestCase
     {
         $this->expectException(HttpException::class);
         $this->expectExceptionCode(400);
-        $this->expectExceptionMessage('Received a 400 error for GeoIP2 Country but could not decode the response as JSON: Syntax error. Body: { invalid: }');
+        $this->expectExceptionMessage('Received a 400 error for GeoIP Country but could not decode the response as JSON: Syntax error. Body: { invalid: }');
 
         $this->makeRequest('Country', '1.2.3.9');
     }
@@ -382,7 +382,7 @@ class ClientTest extends TestCase
     {
         $this->expectException(HttpException::class);
         $this->expectExceptionCode(300);
-        $this->expectExceptionMessage('Received an unexpected HTTP status (300) for GeoIP2 Country');
+        $this->expectExceptionMessage('Received an unexpected HTTP status (300) for GeoIP Country');
 
         $this->makeRequest('Country', '1.2.3.11');
     }
@@ -391,7 +391,7 @@ class ClientTest extends TestCase
     {
         $this->expectException(HttpException::class);
         $this->expectExceptionCode(406);
-        $this->expectExceptionMessage('Received a 406 error for GeoIP2 Country with the following body: Cannot satisfy your Accept-Charset requirements');
+        $this->expectExceptionMessage('Received a 406 error for GeoIP Country with the following body: Cannot satisfy your Accept-Charset requirements');
 
         $this->makeRequest('Country', '1.2.3.12');
     }


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2", and changes the web service error-message prefix from "GeoIP2" to "GeoIP" (with matching test + changelog updates). Technical identifiers (namespace, filenames, edition IDs, the geolite.info hostname, the GeoIP2-API user-agent, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)