### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vendor/
 # Claude Code directories
 .claude/
 .claude_cache/
+.lycheecache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,6 @@ vendor/bin/phpunit
 ## Additional Resources
 
 - [API Documentation](https://maxmind.github.io/GeoIP2-php/)
-- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services)
+- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services/)
 - [MaxMind DB Format](https://maxmind.github.io/MaxMind-DB/)
 - GitHub Issues: https://github.com/maxmind/GeoIP2-php/issues

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Description
 
 This package provides an API for the GeoIP and GeoLite
-[web services](https://dev.maxmind.com/geoip/docs/web-services?lang=en) and
-[databases](https://dev.maxmind.com/geoip/docs/databases?lang=en).
+[web services](https://dev.maxmind.com/geoip/docs/web-services/?lang=en) and
+[databases](https://dev.maxmind.com/geoip/docs/databases/?lang=en).
 
 ## Install via Composer
 
@@ -45,18 +45,18 @@ require 'vendor/autoload.php';
 ## Install via Phar
 
 Although we strongly recommend using Composer, we also provide a
-[phar archive](https://php.net/manual/en/book.phar.php) containing most of the
+[phar archive](https://www.php.net/manual/en/book.phar.php) containing most of the
 dependencies for GeoIP. Our latest phar archive is available on
 [our releases page](https://github.com/maxmind/GeoIP2-php/releases).
 
 ### Install Dependencies
 
 In order to use the phar archive, you must have the PHP
-[Phar extension](https://php.net/manual/en/book.phar.php) installed and
+[Phar extension](https://www.php.net/manual/en/book.phar.php) installed and
 enabled.
 
 If you will be making web service requests, you must have the PHP
-[cURL extension](https://php.net/manual/en/book.curl.php) installed to use
+[cURL extension](https://www.php.net/manual/en/book.curl.php) installed to use
 this archive. For Debian-based distributions, this can typically be found in
 the `php-curl` package. For other operating systems, please consult the
 relevant documentation. After installing the extension you may need to restart
@@ -286,7 +286,7 @@ print($record->network . "\n"); // '128.101.101.101/32'
 
 You can keep your databases up to date with our
 [GeoIP Update program](https://github.com/maxmind/geoipupdate/releases).
-[Learn more about GeoIP Update on our developer portal.](https://dev.maxmind.com/geoip/updating-databases?lang=en)
+[Learn more about GeoIP Update on our developer portal.](https://dev.maxmind.com/geoip/updating-databases/?lang=en)
 
 ## Web Service Client
 
@@ -398,7 +398,7 @@ Because of these factors, it is possible for any endpoint to return a record
 where some or all of the attributes are unpopulated.
 
 See the
-[GeoIP web service docs](https://dev.maxmind.com/geoip/docs/web-services?lang=en)
+[GeoIP web service docs](https://dev.maxmind.com/geoip/docs/web-services/?lang=en)
 for details on what data each endpoint may return.
 
 The only piece of data which is always returned is the `ipAddress` attribute
@@ -422,7 +422,7 @@ GeoNames premium data set.
 ## Reporting data problems
 
 If the problem you find is that an IP address is incorrectly mapped, please
-[submit your correction to MaxMind](https://www.maxmind.com/en/correction).
+[submit your correction to MaxMind](https://www.maxmind.com/en/geoip-data-correction-request).
 
 If you find some other sort of mistake, like an incorrect spelling, please
 check the [GeoNames site](https://www.geonames.org/) first. Once you've
@@ -433,7 +433,7 @@ automatically incorporated into future MaxMind releases.
 
 If you are a paying MaxMind customer and you're not sure where to submit a
 correction, please
-[contact MaxMind support](https://www.maxmind.com/en/support) for help.
+[contact MaxMind support](https://support.maxmind.com/knowledge-base) for help.
 
 ## Other Support
 
@@ -441,7 +441,7 @@ Please report all issues with this code using the
 [GitHub issue tracker](https://github.com/maxmind/GeoIP2-php/issues).
 
 If you are having an issue with a MaxMind service that is not specific to the
-client API, please see [our support page](https://www.maxmind.com/en/support).
+client API, please see [our support page](https://support.maxmind.com/knowledge-base).
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {
             "name": "Gregory J. Oschwald",
             "email": "goschwald@maxmind.com",
-            "homepage": "https://www.maxmind.com/"
+            "homepage": "https://www.maxmind.com/en/home"
         }
     ],
     "require": {

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,56 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md' './src/**/*.php' './composer.json'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and updated
+# to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    '^file://',
+    # Live / auth-gated endpoints that appear as string literals or require login
+    '^https://geoip\.maxmind\.com',
+    '^https://geolite\.info',
+    '^https://minfraud\.maxmind\.com',
+    '^https://sandbox\.maxmind\.com',
+    '^https://updates\.maxmind\.com',
+    '^https://www\.maxmind\.com/en/accounts/',
+    'https://www\.maxmind\.com/en/account/login',
+    # Placeholders / local
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (treated as regular expressions)
+exclude_path = [
+    '(^|/)node_modules/',
+    '(^|/)vendor/',
+    # Generated Hugo docs site committed under docs/public
+    '(^|/)docs/public/',
+    '(^|/)\.git/',
+    # Changelog: historical entries are preserved as-is, not rewritten
+    '(^|/)CHANGELOG\.md$',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -31,3 +31,31 @@ url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_
 [tools.hugo."platforms.windows-x64"]
 checksum = "sha256:7f8d030b37600c60bf2a782611257e6a768934fbe7724c1f3a1a501e6724cf0d"
 url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_windows-amd64.zip"
+
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ disable_backends = [
 
 [tools]
 hugo = "latest"
+lychee = "latest"
 
 [hooks]
 enter = "mise install --quiet"
@@ -22,3 +23,7 @@ run = "hugo --source docs --minify"
 [tasks.serve-docs]
 description = "Serve the docs site locally with Hugo dev server"
 run = "hugo server --source docs"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md' './src/**/*.php' './composer.json'"

--- a/src/Model/City.php
+++ b/src/Model/City.php
@@ -13,7 +13,7 @@ use GeoIp2\Record\Subdivision;
  * Model class for the data returned by City Plus web service and City
  * database.
  *
- * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for more
+ * See https://dev.maxmind.com/geoip/docs/web-services/?lang=en for more
  * details.
  */
 class City extends Country

--- a/src/Model/Country.php
+++ b/src/Model/Country.php
@@ -13,7 +13,7 @@ use GeoIp2\Record\Traits;
 /**
  * Model class for the data returned by GeoIP Country web service and database.
  *
- * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for more details.
+ * See https://dev.maxmind.com/geoip/docs/web-services/?lang=en for more details.
  */
 class Country implements \JsonSerializable
 {

--- a/src/Model/Enterprise.php
+++ b/src/Model/Enterprise.php
@@ -7,7 +7,7 @@ namespace GeoIp2\Model;
 /**
  * Model class for the data returned by GeoIP Enterprise database lookups.
  *
- * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for more
+ * See https://dev.maxmind.com/geoip/docs/web-services/?lang=en for more
  * details.
  */
 // phpcs:disable

--- a/src/Model/Insights.php
+++ b/src/Model/Insights.php
@@ -9,7 +9,7 @@ use GeoIp2\Record\Anonymizer;
 /**
  * Model class for the data returned by GeoIP Insights web service.
  *
- * See https://dev.maxmind.com/geoip/docs/web-services?lang=en for
+ * See https://dev.maxmind.com/geoip/docs/web-services/?lang=en for
  * more details.
  */
 class Insights extends City


### PR DESCRIPTION
Validated every link in the repo with the [lychee](https://lychee.cli.rs/) link checker and updated those that were stale or redirecting. Also adds a lychee config and a Links CI workflow (push, pull request, weekly schedule) so link rot is caught automatically going forward. `max_redirects = 0` so any moved link is surfaced and updated to its canonical destination.

Final lychee result: `36 OK, 0 Errors, 2 Excluded`.

## Links updated (old -> new)

- `https://www.maxmind.com/` -> `https://www.maxmind.com/en/home` (composer.json)
- `https://dev.maxmind.com/geoip/docs/web-services` -> `https://dev.maxmind.com/geoip/docs/web-services/` (CLAUDE.md)
- `https://dev.maxmind.com/geoip/docs/web-services?lang=en` -> `https://dev.maxmind.com/geoip/docs/web-services/?lang=en` (README.md, src/Model/City.php, Country.php, Enterprise.php, Insights.php)
- `https://dev.maxmind.com/geoip/docs/databases?lang=en` -> `https://dev.maxmind.com/geoip/docs/databases/?lang=en` (README.md)
- `https://dev.maxmind.com/geoip/updating-databases?lang=en` -> `https://dev.maxmind.com/geoip/updating-databases/?lang=en` (README.md)
- `https://php.net/manual/en/book.phar.php` -> `https://www.php.net/manual/en/book.phar.php` (README.md)
- `https://php.net/manual/en/book.curl.php` -> `https://www.php.net/manual/en/book.curl.php` (README.md)
- `https://www.maxmind.com/en/correction` -> `https://www.maxmind.com/en/geoip-data-correction-request` (README.md)
- `https://www.maxmind.com/en/support` -> `https://support.maxmind.com/knowledge-base` (README.md, 2 occurrences)

Historical `CHANGELOG.md` entries are intentionally left unchanged (excluded via `exclude_path`).

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)