### PR TITLE
Add residential property to Anonymizer record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 CHANGELOG
 =========
 
-3.3.1 (unreleased)
+3.4.0 (unreleased)
 ------------------
 
+* A new `residential` property has been added to `GeoIp2\Record\Anonymizer`.
+  This property is an instance of the new `GeoIp2\Record\AnonymizerFeed`
+  class and provides residential proxy data for the network, including
+  `confidence`, `networkLastSeen`, and `providerName`. This may be the only
+  property with data even when the other anonymizer properties are unset.
+  This data is available from the GeoIP Insights web service.
 * Updated the `GeoIp2\Model\City` constructor to handle an empty
   `subdivisions` array. This provides compatibility with some third-party
   databases that publish empty subdivisions arrays. Pull request by Jarek

--- a/src/Record/Anonymizer.php
+++ b/src/Record/Anonymizer.php
@@ -71,6 +71,14 @@ class Anonymizer implements \JsonSerializable
     public readonly ?string $providerName;
 
     /**
+     * @var AnonymizerFeed Residential proxy data for the network. This may be the only
+     *                     property with data even when the other anonymizer properties are
+     *                     unset. This attribute is only available from the GeoIP Insights
+     *                     web service.
+     */
+    public readonly AnonymizerFeed $residential;
+
+    /**
      * @ignore
      *
      * @param array<string, mixed> $record
@@ -86,6 +94,7 @@ class Anonymizer implements \JsonSerializable
         $this->isTorExitNode = $record['is_tor_exit_node'] ?? false;
         $this->networkLastSeen = $record['network_last_seen'] ?? null;
         $this->providerName = $record['provider_name'] ?? null;
+        $this->residential = new AnonymizerFeed($record['residential'] ?? []);
     }
 
     /**
@@ -121,6 +130,10 @@ class Anonymizer implements \JsonSerializable
         }
         if ($this->providerName !== null) {
             $js['provider_name'] = $this->providerName;
+        }
+        $residential = $this->residential->jsonSerialize();
+        if (!empty($residential)) {
+            $js['residential'] = $residential;
         }
 
         return $js;

--- a/src/Record/AnonymizerFeed.php
+++ b/src/Record/AnonymizerFeed.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeoIp2\Record;
+
+/**
+ * Contains data for one type of anonymizer detection, currently residential
+ * proxies. Additional anonymizer types may be added in the future.
+ *
+ * This record is returned by the GeoIP Insights web service.
+ */
+class AnonymizerFeed implements \JsonSerializable
+{
+    /**
+     * @var int|null A score ranging from 1 to 99 that represents our percent confidence
+     *               that the network is currently part of this anonymizer feed. This
+     *               attribute is only available from the GeoIP Insights web service.
+     */
+    public readonly ?int $confidence;
+
+    /**
+     * @var string|null The last day that the network was sighted in our analysis of this
+     *                  anonymizer feed, in YYYY-MM-DD format. This attribute is only
+     *                  available from the GeoIP Insights web service.
+     */
+    public readonly ?string $networkLastSeen;
+
+    /**
+     * @var string|null The name of the provider associated with the network in this
+     *                  anonymizer feed. This attribute is only available from the GeoIP
+     *                  Insights web service.
+     */
+    public readonly ?string $providerName;
+
+    /**
+     * @ignore
+     *
+     * @param array<string, mixed> $record
+     */
+    public function __construct(array $record)
+    {
+        $this->confidence = $record['confidence'] ?? null;
+        $this->networkLastSeen = $record['network_last_seen'] ?? null;
+        $this->providerName = $record['provider_name'] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $js = [];
+
+        if ($this->confidence !== null) {
+            $js['confidence'] = $this->confidence;
+        }
+        if ($this->networkLastSeen !== null) {
+            $js['network_last_seen'] = $this->networkLastSeen;
+        }
+        if ($this->providerName !== null) {
+            $js['provider_name'] = $this->providerName;
+        }
+
+        return $js;
+    }
+}

--- a/tests/GeoIp2/Test/Model/InsightsTest.php
+++ b/tests/GeoIp2/Test/Model/InsightsTest.php
@@ -27,6 +27,11 @@ class InsightsTest extends TestCase
                 'is_tor_exit_node' => true,
                 'network_last_seen' => '2025-04-14',
                 'provider_name' => 'NordVPN',
+                'residential' => [
+                    'confidence' => 82,
+                    'network_last_seen' => '2026-05-11',
+                    'provider_name' => 'quickshift',
+                ],
             ],
             'city' => [
                 'confidence' => 76,
@@ -232,6 +237,30 @@ class InsightsTest extends TestCase
             '$model->anonymizer->providerName is NordVPN'
         );
 
+        $this->assertInstanceOf(
+            'GeoIp2\Record\AnonymizerFeed',
+            $model->anonymizer->residential,
+            '$model->anonymizer->residential'
+        );
+
+        $this->assertSame(
+            82,
+            $model->anonymizer->residential->confidence,
+            '$model->anonymizer->residential->confidence is 82'
+        );
+
+        $this->assertSame(
+            '2026-05-11',
+            $model->anonymizer->residential->networkLastSeen,
+            '$model->anonymizer->residential->networkLastSeen is 2026-05-11'
+        );
+
+        $this->assertSame(
+            'quickshift',
+            $model->anonymizer->residential->providerName,
+            '$model->anonymizer->residential->providerName is quickshift'
+        );
+
         $this->assertSame(
             15.37,
             $model->traits->ipRiskSnapshot,
@@ -385,10 +414,74 @@ class InsightsTest extends TestCase
                     'is_tor_exit_node' => true,
                     'network_last_seen' => '2025-04-14',
                     'provider_name' => 'NordVPN',
+                    'residential' => [
+                        'confidence' => 82,
+                        'network_last_seen' => '2026-05-11',
+                        'provider_name' => 'quickshift',
+                    ],
                 ],
             ],
             $model->jsonSerialize(),
             'jsonSerialize returns initial array'
+        );
+    }
+
+    public function testAnonymizerResidentialOnly(): void
+    {
+        // Residential proxy data may be present even when the other
+        // anonymizer properties are unset, so the anonymizer object may
+        // be returned with only the residential key set.
+        $raw = [
+            'traits' => ['ip_address' => '6.0.42.17'],
+            'anonymizer' => [
+                'residential' => [
+                    'confidence' => 95,
+                    'network_last_seen' => '2026-05-14',
+                    'provider_name' => 'novada',
+                ],
+            ],
+        ];
+
+        $model = new Insights($raw, ['en']);
+
+        $this->assertNull(
+            $model->anonymizer->confidence,
+            '$model->anonymizer->confidence is null'
+        );
+
+        $this->assertFalse(
+            $model->anonymizer->isAnonymous,
+            '$model->anonymizer->isAnonymous is false'
+        );
+
+        $this->assertInstanceOf(
+            'GeoIp2\Record\AnonymizerFeed',
+            $model->anonymizer->residential,
+            '$model->anonymizer->residential'
+        );
+
+        $this->assertSame(
+            95,
+            $model->anonymizer->residential->confidence,
+            '$model->anonymizer->residential->confidence is 95'
+        );
+
+        $this->assertSame(
+            '2026-05-14',
+            $model->anonymizer->residential->networkLastSeen,
+            '$model->anonymizer->residential->networkLastSeen is 2026-05-14'
+        );
+
+        $this->assertSame(
+            'novada',
+            $model->anonymizer->residential->providerName,
+            '$model->anonymizer->residential->providerName is novada'
+        );
+
+        $this->assertSame(
+            $raw,
+            $model->jsonSerialize(),
+            'jsonSerialize returns only the residential key in anonymizer'
         );
     }
 
@@ -456,6 +549,33 @@ class InsightsTest extends TestCase
             'GeoIp2\Record\Traits',
             $model->traits,
             '$model->traits'
+        );
+
+        $this->assertInstanceOf(
+            'GeoIp2\Record\Anonymizer',
+            $model->anonymizer,
+            '$model->anonymizer'
+        );
+
+        $this->assertInstanceOf(
+            'GeoIp2\Record\AnonymizerFeed',
+            $model->anonymizer->residential,
+            '$model->anonymizer->residential'
+        );
+
+        $this->assertNull(
+            $model->anonymizer->residential->confidence,
+            '$model->anonymizer->residential->confidence is null'
+        );
+
+        $this->assertNull(
+            $model->anonymizer->residential->networkLastSeen,
+            '$model->anonymizer->residential->networkLastSeen is null'
+        );
+
+        $this->assertNull(
+            $model->anonymizer->residential->providerName,
+            '$model->anonymizer->residential->providerName is null'
         );
 
         $this->assertSame(


### PR DESCRIPTION
## Summary

The GeoIP Insights web service is adding a `residential` sub-object to the `anonymizer` object. It contains residential proxy data for the network and may be populated even when no other anonymizer properties are set.

- New reusable record for the feed shape (`confidence`, `network_last_seen`, `provider_name`) named `AnonymizerFeed`, so future anonymizer feeds can share it
- New `residential` property on the `Anonymizer` record
- Tests, fixtures, and changelog updated

`residential` is always constructed (an empty `AnonymizerFeed` when there is no data), matching the library's existing sub-object pattern, and is omitted from `jsonSerialize()` output when empty.

## Testing

`phpunit`, `php-cs-fixer`, `phpcs`, and `phpstan` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for residential anonymizer information in Insights results.
  * Residential data can include confidence, last-seen network date, and provider name.
  * Results may contain residential anonymizer data even when other anonymizer details are unavailable.
  * Empty residential data is omitted from serialized responses.

* **Documentation**
  * Updated the unreleased changelog entry for version 3.4.0 with residential anonymizer details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->