### PR TITLE
Run Dependabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: composer
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: '14:00'
     open-pull-requests-limit: 10
     cooldown:
@@ -11,7 +12,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: '14:00'
     cooldown:
       default-days: 7


### PR DESCRIPTION
We now review dependency updates weekly rather than daily, so switch every Dependabot update schedule to weekly on Monday mornings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency and automation update checks will now run weekly on Mondays instead of daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->